### PR TITLE
Client can Delete a Priority

### DIFF
--- a/src/components/achievements/Achievement.js
+++ b/src/components/achievements/Achievement.js
@@ -8,6 +8,7 @@ import * as AiIcons from "react-icons/ai"
 
 export const Achievement = ({ achievement }) => {
     // returns indivdual achievements to achievement list
+    const { deleteAchievement } = useContext(AchievementContext)
     const history = useHistory()
 
     return (

--- a/src/components/achievements/Achievement.js
+++ b/src/components/achievements/Achievement.js
@@ -20,7 +20,9 @@ export const Achievement = ({ achievement }) => {
                     <Card.Body>
                         <Card.Subtitle><div>{achievement.created_on}</div></Card.Subtitle>
                         <Card.Text><div>{achievement.content}</div></Card.Text>
-                        <Button>Delete</Button>
+                        <Button onClick={() => {
+                            deleteAchievement(achievement.id)
+                        }}>Delete</Button>
                     </Card.Body>
                 </Card>
               </>

--- a/src/components/achievements/AchievementsProvider.js
+++ b/src/components/achievements/AchievementsProvider.js
@@ -15,13 +15,22 @@ export const AchievementProvider = (props) => {
         .then(setAchievement)
     }
 
-    // TODO: create deleteAchievement for deleting a priority to complete CRUD
+    const deleteAchievement = priorityId => {
+        return fetch(`http://localhost:8000/priorities/${priorityId}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(getAchievements)
+    }
 
 
     return (
         <AchievementContext.Provider value={
             {
-                achievements, getAchievements
+                achievements, getAchievements,
+                deleteAchievement
             }
         }>
             {props.children}

--- a/src/components/priorities/PriorityList.js
+++ b/src/components/priorities/PriorityList.js
@@ -13,6 +13,10 @@ export const PriorityList = () => {
         getPriorities()
     }, [])
 
+    const sortedPriorities = priorities.sort((a, b) => {
+        return b.created_on.localeCompare(a.created_on)
+    })
+
 
     return (
         <>
@@ -30,7 +34,7 @@ export const PriorityList = () => {
                     <Col> 
                         Your Current Priorities:
                         {
-                            priorities.map(priority => {
+                            sortedPriorities.map(priority => {
                                 return <Priority priorityObject={priority} key={priority.id} />
                             })
                         }


### PR DESCRIPTION
## Changes

- added `delete` fetch call to provider
- added ability to sort priorities by creation date, newest at the top
- added delete function to delete button on a priority to remove it from the database


## Testing

- [ ] git fetch --all and checkout to branch `client-delete-priority`
- [ ] run server from `stressLess-server`
- [ ] navigate to achievements page and click delete on a priority
- [ ] verify a `204 No Content` network response and that the priority is removed from the list 


## Related Issues

- Fixes #9