### PR TITLE
Client can Read Reflections

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -6,23 +6,27 @@ import { PriorityProvider } from "./priorities/PriorityProvider"
 import { PriorityForm } from "./priorities/PriorityForm"
 import { AchievementProvider } from "./achievements/AchievementsProvider"
 import { AchievementList } from "./achievements/AchievementList"
+import { ReflectionProvider } from "./reflections/ReflectionProvider"
+
 
 export const ApplicationViews = () => {
     return <>
         {/* Render user dashboard upon login */}
         <DashboardProvider>
             <PriorityProvider>
-                <Route exact path="/dashboard">
-                    <Dashboard />
-                </Route>
+                <ReflectionProvider>
+                    <Route exact path="/dashboard">
+                        <Dashboard />
+                    </Route>
 
-                <Route exact path="/priority/new">
-                    <PriorityForm />
-                </Route>
+                    <Route exact path="/priority/new">
+                        <PriorityForm />
+                    </Route>
 
-                <Route exact path="/priority/:priorityId(\d+)/edit">
-                    <PriorityForm />
-                </Route>
+                    <Route exact path="/priority/:priorityId(\d+)/edit">
+                        <PriorityForm />
+                    </Route>
+                </ReflectionProvider>
             </PriorityProvider>
         </DashboardProvider>
 

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext, useState } from "react"
 import { DashboardContext } from "./DashboardProvider"
 import { PriorityList } from "../priorities/PriorityList"
+import { ReflectionList } from "../reflections/ReflectionList.js"
 import { Container, Row, Col } from "react-bootstrap"
 import "./Dashboard.css"
 
@@ -20,7 +21,7 @@ export const Dashboard = () => {
                 </Row>
                 <Row>
                     <Col sm={12} md={6}> <PriorityList/> </Col>
-                    <Col sm={12} md={6}>Quick Reflections - reflections component</Col>
+                    <Col sm={12} md={6}> <ReflectionList/> </Col>
                 </Row>
             </Container>
         </>

--- a/src/components/reflections/Reflection.js
+++ b/src/components/reflections/Reflection.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useContext, useState } from "react"
+import { ReflectionContext } from "./ReflectionProvider"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button, Card } from "react-bootstrap"
+import { DateTime } from "luxon"
+import * as BsIcons from "react-icons/bs"
+
+
+export const Reflection = ({ reflectionObj }) => {
+    // returns individual reflections to reflection list
+
+    
+    
+    return (
+        <>
+            {
+                (reflectionObj.owner)
+                ? <>
+                    <Card>
+                        <Card.Body>
+                            <Card.Subtitle><div>{reflectionObj.created_on}</div></Card.Subtitle>
+                            <Card.Text><div>{reflectionObj.content}</div></Card.Text>
+                            <Card.Link><BsIcons.BsTrashFill/></Card.Link>
+                        </Card.Body>
+                    </Card>
+                  </>
+                : <></>
+            }
+        </>
+    )
+}
+

--- a/src/components/reflections/ReflectionList.js
+++ b/src/components/reflections/ReflectionList.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useContext, useState } from "react"
+import { ReflectionContext } from "./ReflectionProvider"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button } from "react-bootstrap"
+
+
+export const ReflectionList = () => {
+    const { reflections, getReflections } = useContext(ReflectionContext)
+
+    useEffect(() => {
+        getReflections()
+    }, [])
+
+
+    return (
+        <>
+            <Container>
+                <Row>
+                    <Col>
+                        New Reflection Input HERE
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        Current Reflections here:
+                    </Col>
+                </Row>
+            </Container>
+        </>
+    )
+}

--- a/src/components/reflections/ReflectionList.js
+++ b/src/components/reflections/ReflectionList.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useContext, useState } from "react"
 import { ReflectionContext } from "./ReflectionProvider"
+import { Reflection } from "./Reflection"
 import { useHistory } from 'react-router'
 import { Container, Row, Col, Button } from "react-bootstrap"
 
@@ -23,6 +24,11 @@ export const ReflectionList = () => {
                 <Row>
                     <Col>
                         Current Reflections here:
+                        {
+                            reflections.map(reflection => {
+                                return <Reflection reflectionObj={reflection} key={reflection.id} />
+                            })
+                        }
                     </Col>
                 </Row>
             </Container>

--- a/src/components/reflections/ReflectionProvider.js
+++ b/src/components/reflections/ReflectionProvider.js
@@ -1,0 +1,39 @@
+import React, { useState, createContext } from 'react'
+
+export const ReflectionContext = createContext()
+
+export const ReflectionProvider = (props) => {
+    const [reflections, setReflections] = useState([])
+
+    const getReflections = () => {
+        return fetch("http://localhost:8000/reflections", {
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(res => res.json())
+        .then(setReflections)
+    }
+
+    const deleteReflection = reflectionId => {
+        return fetch(`http://localhost:8000/reflections/${reflectionId}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(getReflections)
+    }
+
+
+    return (
+        <ReflectionContext.Provider value={
+            {
+                reflections, getReflections,
+                deleteReflection
+            }
+        }>
+            {props.children}
+        </ReflectionContext.Provider>
+    )
+}


### PR DESCRIPTION
## Changes

- added reflections directory and provider, along with `reflectionlist.js` and `reflection.js` components
- updated applicationviews with additional provider
- added `reflectionlist.js` to `dashboard.js`
- added `reflection.js` to `reflectionlist.js` to render individual reflections

## Testing

- [ ] git fetch --all and checkout to branch `client-reflection-read`
- [ ] run server from `stressLess-server`
- [ ] login and verify reflections render on dashboard
- [ ] if user doesn't have any current reflections, none will show, only the creator of the reflection will see theirs


## Related Issues

- Fixes #19