### PR TITLE
Client can delete a Reflection

### DIFF
--- a/src/components/reflections/Reflection.js
+++ b/src/components/reflections/Reflection.js
@@ -8,7 +8,7 @@ import * as BsIcons from "react-icons/bs"
 
 export const Reflection = ({ reflectionObj }) => {
     // returns individual reflections to reflection list
-
+    const { deleteReflection } = useContext(ReflectionContext)
     
     
     return (
@@ -20,7 +20,9 @@ export const Reflection = ({ reflectionObj }) => {
                         <Card.Body>
                             <Card.Subtitle><div>{reflectionObj.created_on}</div></Card.Subtitle>
                             <Card.Text><div>{reflectionObj.content}</div></Card.Text>
-                            <Card.Link><BsIcons.BsTrashFill/></Card.Link>
+                            <Card.Link onClick={() => {
+                                deleteReflection(reflectionObj.id)
+                            }}><BsIcons.BsTrashFill/></Card.Link>
                         </Card.Body>
                     </Card>
                   </>

--- a/src/components/reflections/ReflectionInput.js
+++ b/src/components/reflections/ReflectionInput.js
@@ -32,15 +32,20 @@ export const ReflectionInput = () => {
             content: currentReflection.content,
             createdOn: now.toISODate()
         }
-        // send POST request to API
-        createReflection(newReflection)
-            .then(() => {
-                setCurrentReflection({
-                    appUser: currentUser,
-                    content: "",
-                    createdOn: ""
+
+        if (currentReflection.content === "") {
+            return
+        } else {
+            // send POST request to API
+            createReflection(newReflection)
+                .then(() => {
+                    setCurrentReflection({
+                        appUser: currentUser,
+                        content: "",
+                        createdOn: ""
+                    })
                 })
-            })
+        }
     }
 
     return (


### PR DESCRIPTION
## Changes

- added `delete` function to delete button onClick
- added conditional to keep users from creating and saving an `empty` reflection

## Testing

- [ ] git fetch --all and checkout to branch `client-reflection-delete`
- [ ] run server from `stressLess-server`
- [ ] on dashboard click on trash icon to delete a reflection
- [ ] verify `204` No Content` network response and that the reflection was removed from the list
- [ ] try to create a new reflection with an empty input
- [ ] verify you cannot submit 

## Related Issues

- Fixes #11