### PR TITLE
Client can Edit a Post

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -49,6 +49,10 @@ export const ApplicationViews = () => {
             <Route exact path="/post/new">
                 <PostForm />
             </Route>
+
+            <Route exact path="/post/:postId(\d+)/edit">
+                <PostForm />
+            </Route>
         </PostProvider>
     </>
 }

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -3,10 +3,12 @@ import { useHistory } from 'react-router'
 import { Container, Row, Col, Button, Card } from "react-bootstrap"
 import { DateTime } from "luxon"
 import * as BsIcons from "react-icons/bs"
+import * as AiIcons from "react-icons/ai"
 
 
 export const Post = ({ postObject }) => {
     // returns individual posts to post list
+    const history = useHistory()
     
     return (
         <>
@@ -16,10 +18,19 @@ export const Post = ({ postObject }) => {
                     <Card.Title>{postObject.title}</Card.Title>
                     <Card.Text><div>{postObject.content}</div></Card.Text>
                     <Card.Img src={postObject.image_url} />
+                    {
+                        (postObject.owner)
+                        ? <>
+                            <Card.Link onClick={() => {history.push(`/post/${postObject.id}/edit`)}}>
+                                <AiIcons.AiFillEdit /></Card.Link>
+                            <Card.Link><BsIcons.BsTrashFill/></Card.Link>
+                          </>
+                        : <></>
+                    }
                 </Card.Body>
             </Card> 
         </>
     )
 }
 
-// TODO: add ternaries for edit and delete button for (postObject.owner) ONLY
+

--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -21,18 +21,19 @@ export const PostForm = () => {
         publicationDate: ""
     })
 
-    // useEffect(() => {
-    //     if (postId) {
-    //         getPostById(postId).then(post => {
-    //             setCurrentPost({
-    //             appUser: priority.app_user,
-    //             content: priority.content,
-    //             createdOn: priority.created_on,
-    //             completed: priority.completed
-    //           })
-    //       })
-    //     }
-    // }, [postId])
+    useEffect(() => {
+        if (postId) {
+            getPostById(postId).then(post => {
+                setCurrentPost({
+                appUser: post.app_user,
+                title: post.title,
+                content: post.content,
+                imageURL: post.image_url,
+                publicationDate: post.publication_date
+              })
+          })
+        }
+    }, [postId])
 
     const handleUserInput = (event) => {
         const newPostState = {...currentPost}
@@ -55,21 +56,22 @@ export const PostForm = () => {
             .then(() => history.push("/community"))
     }
 
-    // const handleEditPriority = (event) => {
-    //     event.preventDefault()
+    const handleEditPost = (event) => {
+        event.preventDefault()
 
-    //     const priority = {
-    //         id: parseInt(priorityId),
-    //         app_user: currentUser,
-    //         content: currentPriority.content,
-    //         createdOn: now.toISODate(),
-    //         completed: false
-    //     }
-    //     // send PUT request to API
-    //     editPriority(priority)
-    //         .then(() => history.push("/dashboard"))
+        const post = {
+            id: parseInt(postId),
+            app_user: currentUser,
+            title: currentPost.title,
+            content: currentPost.content,
+            imageURL: currentPost.imageURL,
+            publicationDate: now.toISO()
+        }
+        // send PUT request to API
+        editPost(post)
+            .then(() => history.push("/community"))
 
-    // }
+    }
 
 return (
       <>
@@ -103,7 +105,7 @@ return (
                 </Form.Group>
                 {
                     (postId)
-                    ? <Button type="submit">Save</Button>
+                    ? <Button type="submit" onClick={handleEditPost}>Save</Button>
                     : <Button type="submit" onClick={handleSavePost}>Submit</Button>
                 }
                 <Button onClick={() => history.goBack()}>Back</Button>


### PR DESCRIPTION
## Changes

- added ternary for `edit/delete` icons to show only for post `owner`
- configured `postform.js` to handle client edits to post
- added new post edit route to `applicationviews.js`


## Testing

- [ ] git fetch --all and checkout to branch `client-post-edit`
- [ ] run server from `stressLess-server`
- [ ] navigate to community feed and find a post you created to edit
- [ ] click edit and verify you're redirected to edit form with post data populated in fields
- [ ] edit and click save, verify redirect to community feed
- [ ] verify edited post is at the top and has been edited successfully with `204 No Content` in newtork 


## Related Issues

- Fixes #14