### PR TITLE
Client can read comments per individual posts

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -10,6 +10,7 @@ import { ReflectionProvider } from "./reflections/ReflectionProvider"
 import { CommunityFeed } from "./community/CommunityFeed"
 import { PostProvider } from "./posts/PostProvider"
 import { PostForm } from "./posts/PostForm"
+import { CommentProvider } from "./comments/CommentProvider"
 
 
 export const ApplicationViews = () => {
@@ -42,17 +43,19 @@ export const ApplicationViews = () => {
 
         {/* Render community feed here (posts & comments) */}
         <PostProvider>
-            <Route exact path="/community">
-                <CommunityFeed />
-            </Route>
+            <CommentProvider>
+                <Route exact path="/community">
+                    <CommunityFeed />
+                </Route>
 
-            <Route exact path="/post/new">
-                <PostForm />
-            </Route>
+                <Route exact path="/post/new">
+                    <PostForm />
+                </Route>
 
-            <Route exact path="/post/:postId(\d+)/edit">
-                <PostForm />
-            </Route>
+                <Route exact path="/post/:postId(\d+)/edit">
+                    <PostForm />
+                </Route>
+            </CommentProvider>
         </PostProvider>
     </>
 }

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -7,12 +7,22 @@ import * as BsIcons from "react-icons/bs"
 import * as AiIcons from "react-icons/ai"
 
 
-export const Comment = () => {
+export const Comment = ({ commentObj, post }) => {
     // returns individual comment to comment list
 
     return (
         <>
-            <div>HEY! I'm a comment rendering!</div>
+            {
+                (commentObj.post_id === post)
+                ? <Card>
+                    <Card.Body>
+                        <Card.Subtitle>{commentObj.app_user?.full_name}</Card.Subtitle>
+                        <Card.Subtitle>{commentObj.created_on}</Card.Subtitle>
+                        <Card.Text>{commentObj.content}</Card.Text>
+                    </Card.Body>
+                 </Card>
+                : null
+            }
         </>
     )
 }

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -1,0 +1,18 @@
+import React, { useEffect, useContext, useState } from "react"
+import { CommentContext } from "./CommentProvider"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button, Card } from "react-bootstrap"
+import { DateTime } from "luxon"
+import * as BsIcons from "react-icons/bs"
+import * as AiIcons from "react-icons/ai"
+
+
+export const Comment = () => {
+    // returns individual comment to comment list
+
+    return (
+        <>
+            <div>HEY! I'm a comment rendering!</div>
+        </>
+    )
+}

--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -5,16 +5,29 @@ import { useHistory } from 'react-router'
 import { Container, Row, Col, Button } from "react-bootstrap"
 
 
-export const CommentList = () => {
+export const CommentList = ({ postId }) => {
     const { comments, getComments } = useContext(CommentContext)
     const history = useHistory()
+
+    useEffect(() => {
+        getComments()
+    }, [])
+
+    const sortedComments = comments.sort((a, b) => {
+        return b.created_on.localeCompare(a.created_on)
+    })
 
     return (
         <>
             <Container>
                 <Row>
                     <Col>
-                        Comments will list here
+                        Comments will list here:
+                        {
+                            sortedComments.map(comment => {
+                                return <Comment commentObj={comment} post={postId} key={comment.id} />
+                            })
+                        }
                     </Col>
                 </Row>
             </Container>

--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useContext, useState } from "react"
+import  { CommentContext } from "./CommentProvider"
+import { Comment } from "./Comment"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button } from "react-bootstrap"
+
+
+export const CommentList = () => {
+    const { comments, getComments } = useContext(CommentContext)
+    const history = useHistory()
+
+    return (
+        <>
+            <Container>
+                <Row>
+                    <Col>
+                        Comments will list here
+                    </Col>
+                </Row>
+            </Container>
+        </>
+    )
+}

--- a/src/components/comments/CommentProvider.js
+++ b/src/components/comments/CommentProvider.js
@@ -1,0 +1,77 @@
+import React, { useState, createContext } from 'react'
+
+export const CommentContext = createContext()
+
+export const CommentProvider = (props) => {
+    const [ comments, setComments ] = useState([])
+
+    const getComments = () => {
+        return fetch("http://localhost:8000/comments", {
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(res => res.json())
+        .then(setComments)
+    }
+
+
+    const createComment = commentObj => {
+        return fetch("http://localhost:8000/comments", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            },
+            body: JSON.stringify(commentObj)
+        })
+        .then(getComments)
+        .then()
+    }
+
+
+    const editComment = comment => {
+        return fetch(`http://localhost:8000/comments/${comment.id}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            },
+            body: JSON.stringify(comment)
+        })
+        .then(getComments)
+        .then()
+    }
+
+
+    const getCommentById = commentId => {
+        return fetch(`http://localhost:8000/comments/${commentId}`, {
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(res => res.json())
+    }
+
+    const deleteComment = commentId => {
+        return fetch(`http://localhost:8000/comments/${commentId}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(getComments)
+    }
+
+
+    return (
+        <CommentContext.Provider value={
+            {
+                comments, getComments, createComment,
+                editComment, getCommentById, deleteComment
+            }
+        }>
+            {props.children}
+        </CommentContext.Provider>
+    )
+}

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -37,7 +37,7 @@ export const Post = ({ postObject }) => {
                     <Card.Link onClick={() => setShowMe(!showMe)}>Comments</Card.Link>
                     {
                         (showMe)
-                        ? <><CommentList/></>
+                        ? <><CommentList postId={postObject.id}/></>
                         : null
                     }
                 </Card.Body>

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useContext, useState } from "react"
 import { PostContext } from "./PostProvider"
+import { CommentList } from "../comments/CommentList"
 import { useHistory } from 'react-router'
 import { Container, Row, Col, Button, Card } from "react-bootstrap"
 import { DateTime } from "luxon"
@@ -36,7 +37,7 @@ export const Post = ({ postObject }) => {
                     <Card.Link onClick={() => setShowMe(!showMe)}>Comments</Card.Link>
                     {
                         (showMe)
-                        ? <><div>Comment Component HERE</div></>
+                        ? <><CommentList/></>
                         : null
                     }
                 </Card.Body>

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -11,6 +11,8 @@ export const Post = ({ postObject }) => {
     // returns individual posts to post list
     const { deletePost } = useContext(PostContext)
     const history = useHistory()
+
+    const [ showMe, setShowMe ] = useState(false)
     
     return (
         <>
@@ -30,6 +32,12 @@ export const Post = ({ postObject }) => {
                             }}><BsIcons.BsTrashFill/></Card.Link>
                           </>
                         : <></>
+                    }
+                    <Card.Link onClick={() => setShowMe(!showMe)}>Comments</Card.Link>
+                    {
+                        (showMe)
+                        ? <><div>Comment Component HERE</div></>
+                        : null
                     }
                 </Card.Body>
             </Card> 


### PR DESCRIPTION
## Changes

- added `comment` dir with provider and complete crud fetch calls
- created components to handle render of individual `comment.js`,  which lives in `commentlist.js`, which lives in `post.js`
- added state to `hide/show` comments for each post
- passed postId to `comment.js` component, then used ternary to only show comments for the post they're related to


## Testing

- [ ] git fetch --all and checkout to branch `client-comment-read`
- [ ] run server from `stressLess-server`
- [ ] navigate to community feed and click on comments
- [ ] verify a hidden element shows
- [ ] verify the last post has two comments rendering when comments clicked


## Related Issues

- Fixes #20