### PR TITLE
Client can Edit a comment

### DIFF
--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -31,11 +31,6 @@ export const Comment = ({ commentObj, post }) => {
         createdOn: ""
     })
 
-    const handleUserInput = (event) => {
-        const newCommentState = {...currentComment}
-        newCommentState[event.target.name] = event.target.value
-        setCurrentComment(newCommentState)
-    }
 
     useEffect(() => {
         if (edit === true) {
@@ -49,6 +44,30 @@ export const Comment = ({ commentObj, post }) => {
             })
         }
     }, [edit])
+
+
+    const handleUserInput = (event) => {
+        const newCommentState = {...currentComment}
+        newCommentState[event.target.name] = event.target.value
+        setCurrentComment(newCommentState)
+    }
+
+    const handleEditComment = (event) => {
+        event.preventDefault()
+
+        const comment = {
+            id: commentObj.id,
+            postId: postId,
+            appUser: currentUser,
+            content: currentComment.content,
+            createdOn: currentComment.createdOn
+        }
+        // send PUT request to API
+        editComment(comment)
+            .then(() => {
+                setEdit(false)
+            })
+    }
 
     return (
         <>
@@ -67,17 +86,18 @@ export const Comment = ({ commentObj, post }) => {
                                         <Col>
                                             <Form>
                                                 <Form.Group>
-                                                    <Form.Label>Write a comment..</Form.Label>
-                                                    <Form.Control as="textarea" rows={1}
+                                                    <Form.Control as="textarea" rows={4}
                                                     name="content" value={currentComment.content}
                                                     onChange={handleUserInput} required/>
-                                                    <Button>Submit</Button>
-                                                    <Button onClick={() => setEdit(!edit)}>Cancel</Button>
+                                                    <Button onClick={handleEditComment}>Save</Button>
+                                                    <Button onClick={() => 
+                                                        setEdit(!edit)}>Cancel</Button>
                                                 </Form.Group>
                                             </Form>
                                         </Col>
                                     </Row>
                                 </Container>
+                                {console.log(commentObj.id)}
                               </>
                             : <>
                                 <Card.Text>{commentObj.content}</Card.Text>

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext, useState } from "react"
 import { CommentContext } from "./CommentProvider"
 import { useHistory } from 'react-router'
-import { Container, Row, Col, Button, Card } from "react-bootstrap"
+import { Container, Row, Col, Button, Card, Form } from "react-bootstrap"
 import { DateTime } from "luxon"
 import * as BsIcons from "react-icons/bs"
 import * as AiIcons from "react-icons/ai"
@@ -9,6 +9,10 @@ import * as AiIcons from "react-icons/ai"
 
 export const Comment = ({ commentObj, post }) => {
     // returns individual comment to comment list
+    const { editComment, getCommentById } = useContext(CommentContext)
+    const currentUser = localStorage.getItem("stressLess_user_id")
+    const now = DateTime.now()
+    const postId = post
 
     // making date readable to humans
     // const monthDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' }
@@ -18,6 +22,34 @@ export const Comment = ({ commentObj, post }) => {
     const humanMonthDate = date.toLocaleDateString('en-US', monthDate)
     const humanTime = date.toLocaleString('en-US', time)
 
+    const [ edit, setEdit ] = useState(false)
+
+    const [ currentComment, setCurrentComment ] = useState({
+        postId: postId,
+        appUser: currentUser,
+        content: "",
+        createdOn: ""
+    })
+
+    const handleUserInput = (event) => {
+        const newCommentState = {...currentComment}
+        newCommentState[event.target.name] = event.target.value
+        setCurrentComment(newCommentState)
+    }
+
+    useEffect(() => {
+        if (edit === true) {
+            getCommentById(commentObj.id).then(comment => {
+                setCurrentComment({
+                    postId: comment.post_id,
+                    appUser: comment.app_user,
+                    content: comment.content,
+                    createdOn: comment.created_on
+                })
+            })
+        }
+    }, [edit])
+
     return (
         <>
             {
@@ -26,16 +58,42 @@ export const Comment = ({ commentObj, post }) => {
                     <Card.Body>
                         <Card.Subtitle>{commentObj.app_user?.full_name}</Card.Subtitle>
                         <Card.Subtitle>{humanMonthDate} at {humanTime}</Card.Subtitle>
-                        <Card.Text>{commentObj.content}</Card.Text>
+                        {/* ternary to show comment OR if EDIT is TRUE, show comment input form to edit comment */}
                         {
-                            (commentObj.owner)
+                            (edit)
+                            ? <>
+                                <Container>
+                                    <Row>
+                                        <Col>
+                                            <Form>
+                                                <Form.Group>
+                                                    <Form.Label>Write a comment..</Form.Label>
+                                                    <Form.Control as="textarea" rows={1}
+                                                    name="content" value={currentComment.content}
+                                                    onChange={handleUserInput} required/>
+                                                    <Button>Submit</Button>
+                                                    <Button onClick={() => setEdit(!edit)}>Cancel</Button>
+                                                </Form.Group>
+                                            </Form>
+                                        </Col>
+                                    </Row>
+                                </Container>
+                              </>
+                            : <>
+                                <Card.Text>{commentObj.content}</Card.Text>
+                              </>
+                        }
+                        {/* show edit and delete buttons if user is OWNER and edit is FALSE */}
+                        {
+                            (commentObj.owner && edit === false)
                             ? <>
                                 <Button><BsIcons.BsTrashFill/></Button>
-                                <Button><AiIcons.AiFillEdit/></Button>
+                                <Button onClick={() => 
+                                    setEdit(!edit)
+                                }><AiIcons.AiFillEdit/></Button>
                               </>
                             : null
-                        }
-                        
+                        } 
                     </Card.Body>
                  </Card>
                 : null
@@ -43,3 +101,6 @@ export const Comment = ({ commentObj, post }) => {
         </>
     )
 }
+
+//TODO: edit through modal? if not figure out how to seed data into comment form
+//TODO: add sweetalert modal to delete function for comments and POSTS

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -27,6 +27,15 @@ export const Comment = ({ commentObj, post }) => {
                         <Card.Subtitle>{commentObj.app_user?.full_name}</Card.Subtitle>
                         <Card.Subtitle>{humanMonthDate} at {humanTime}</Card.Subtitle>
                         <Card.Text>{commentObj.content}</Card.Text>
+                        {
+                            (commentObj.owner)
+                            ? <>
+                                <Button><BsIcons.BsTrashFill/></Button>
+                                <Button><AiIcons.AiFillEdit/></Button>
+                              </>
+                            : null
+                        }
+                        
                     </Card.Body>
                  </Card>
                 : null

--- a/src/components/comments/CommentForm.js
+++ b/src/components/comments/CommentForm.js
@@ -4,12 +4,11 @@ import { PostContext } from "../posts/PostProvider"
 import { useHistory } from 'react-router'
 import { Container, Row, Col, Button, Form } from "react-bootstrap"
 import { DateTime } from "luxon"
-import { faTemperatureLow } from "@fortawesome/free-solid-svg-icons"
 
 
 
 export const CommentForm = ({ inputCollapse, buttonHide, post, commentShow }) => {
-    const { createComment, editComment, getCommentById } = useContext(CommentContext)
+    const { createComment } = useContext(CommentContext)
     const { getPosts } = useContext(PostContext)
     const history = useHistory()
     const currentUser = localStorage.getItem("stressLess_user_id")
@@ -73,6 +72,10 @@ export const CommentForm = ({ inputCollapse, buttonHide, post, commentShow }) =>
                                 name="content" value={currentComment.content}
                                 onChange={handleUserInput} required/>
                                 <Button onClick={handleSaveComment}>Submit</Button>
+                                <Button onClick={() => {
+                                    buttonHide(true)
+                                    inputCollapse(!inputCollapse)
+                                }}>Cancel</Button>
                             </Form.Group>
                         </Form>
                     </Col>


### PR DESCRIPTION
## Changes

- added ternary for ownership to show `delete/edit` buttons if you're the owner of a comment
- added `edit` state and ternary to either show current comment content or show input form that grabs comment by id to edit
- client can edit comments successfully, database updates, and edit input form disappears after save


## Testing

- [ ] git fetch --all and checkout to branch `client-comment-edit`
- [ ] run server from `stressLess-server`
- [ ] navigate to community feed, click comments, then click `edit` icon
- [ ] verify comment context is placed in an input box to be edited
- [ ] edit comment and click save
- [ ] verify comment edit is saved and input box disappears, should see `204 No Content` in network


## Related Issues

- Fixes #17