### PR TITLE
Client can Delete Comment

### DIFF
--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -1,17 +1,18 @@
 import React, { useEffect, useContext, useState } from "react"
 import { CommentContext } from "./CommentProvider"
+import { PostContext } from "../posts/PostProvider"
 import { useHistory } from 'react-router'
 import { Container, Row, Col, Button, Card, Form } from "react-bootstrap"
-import { DateTime } from "luxon"
 import * as BsIcons from "react-icons/bs"
 import * as AiIcons from "react-icons/ai"
+import Swal from "sweetalert2"
 
 
 export const Comment = ({ commentObj, post }) => {
     // returns individual comment to comment list
-    const { editComment, getCommentById } = useContext(CommentContext)
+    const { editComment, getCommentById, deleteComment } = useContext(CommentContext)
+    const { getPosts } = useContext(PostContext)
     const currentUser = localStorage.getItem("stressLess_user_id")
-    const now = DateTime.now()
     const postId = post
 
     // making date readable to humans
@@ -21,9 +22,9 @@ export const Comment = ({ commentObj, post }) => {
     const time = { hour: 'numeric', minute: 'numeric' }
     const humanMonthDate = date.toLocaleDateString('en-US', monthDate)
     const humanTime = date.toLocaleString('en-US', time)
-
+    // setting edit comment state
     const [ edit, setEdit ] = useState(false)
-
+    // setting initial comment state
     const [ currentComment, setCurrentComment ] = useState({
         postId: postId,
         appUser: currentUser,
@@ -69,6 +70,31 @@ export const Comment = ({ commentObj, post }) => {
             })
     }
 
+    const handleDeleteComment = (commentId) => {
+        Swal.fire({
+            title: "Are you sure?",
+            text: "You will not be able to undo!",
+            icon: "warning",
+            showCancelButton: true,
+            confirmButtonText: "Yes, delete it!",
+            cancelButtonText: "Ah, cancel"
+          }).then((result) => {
+            if (result.isConfirmed) {
+              deleteComment(commentId).then(() => {
+                Swal.fire(
+                  "Deleted!",
+                  "Your comment has been deleted.",
+                  "Success!"
+                ).then(() => {
+                    getPosts()
+                })
+              })
+            }; 
+        })
+    }
+
+    
+
     return (
         <>
             {
@@ -107,7 +133,9 @@ export const Comment = ({ commentObj, post }) => {
                         {
                             (commentObj.owner && edit === false)
                             ? <>
-                                <Button><BsIcons.BsTrashFill/></Button>
+                                <Button onClick={() => {
+                                    handleDeleteComment(commentObj.id)
+                                }}><BsIcons.BsTrashFill/></Button>
                                 <Button onClick={() => 
                                     setEdit(!edit)
                                 }><AiIcons.AiFillEdit/></Button>
@@ -121,6 +149,3 @@ export const Comment = ({ commentObj, post }) => {
         </>
     )
 }
-
-//TODO: edit through modal? if not figure out how to seed data into comment form
-//TODO: add sweetalert modal to delete function for comments and POSTS

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -7,11 +7,12 @@ import { Container, Row, Col, Button, Card } from "react-bootstrap"
 import { DateTime } from "luxon"
 import * as BsIcons from "react-icons/bs"
 import * as AiIcons from "react-icons/ai"
+import Swal from "sweetalert2"
 
 
 export const Post = ({ postObject }) => {
     // returns individual posts to post list
-    const { deletePost } = useContext(PostContext)
+    const { deletePost, getPosts } = useContext(PostContext)
     const history = useHistory()
 
     const [ showComments, setShowComments ] = useState(false)
@@ -27,7 +28,29 @@ export const Post = ({ postObject }) => {
     const humanTime = date.toLocaleString('en-US', time)
     
 
-    //TODO: Hook up sweetalert to deletePost function!
+    const handleDeletePost = (postId) => {
+        Swal.fire({
+            title: "Are you sure?",
+            text: "You will not be able to undo!",
+            icon: "warning",
+            showCancelButton: true,
+            confirmButtonText: "Yes, delete it!",
+            cancelButtonText: "Ah, cancel"
+          }).then((result) => {
+            if (result.isConfirmed) {
+              deletePost(postId).then(() => {
+                Swal.fire(
+                  "Deleted!",
+                  "Your comment has been deleted.",
+                  "Success!"
+                ).then(() => {
+                    
+                })
+              })
+            }; 
+        })
+    }
+    
 
     return (
         <>
@@ -43,7 +66,7 @@ export const Post = ({ postObject }) => {
                             <Card.Link onClick={() => {history.push(`/post/${postObject.id}/edit`)}}>
                                 <AiIcons.AiFillEdit /></Card.Link>
                             <Card.Link onClick={() => {
-                                deletePost(postObject.id)
+                                handleDeletePost(postObject.id)
                             }}><BsIcons.BsTrashFill/></Card.Link>
                           </>
                         : <></>
@@ -88,4 +111,4 @@ export const Post = ({ postObject }) => {
 }
 
 
-//TODO: pass setShowCommentInput and setShowButton state to comment input component
+//TODO: pass setShowCommentInput and setShowButton state to comment form component as props


### PR DESCRIPTION
## Changes

- added alert modal for delete function of `comments` and `posts


## Testing

- [ ] git fetch --all and checkout to branch `client-comment-delete`
- [ ] run server from `stressLess-server`
- [ ] navigate to community feed and click `delete` icon on a post you own
- [ ] verify alert modal pops up, click I'm sure to delete
- [ ] verify modal gives you a delete response
- [ ] verify your post has been removed from the post list and network gave a `204 No Content`


## Related Issues

- Fixes last MVP ticket #18