### PR TITLE
Admin permissions to delete all posts and comments

### DIFF
--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext, useState } from "react"
 import { CommentContext } from "./CommentProvider"
 import { PostContext } from "../posts/PostProvider"
-import { useHistory } from 'react-router'
+import { NavBarContext } from "../nav/NavBarProvider"
 import { Container, Row, Col, Button, Card, Form } from "react-bootstrap"
 import * as BsIcons from "react-icons/bs"
 import * as AiIcons from "react-icons/ai"
@@ -11,9 +11,14 @@ import Swal from "sweetalert2"
 export const Comment = ({ commentObj, post }) => {
     // returns individual comment to comment list
     const { editComment, getCommentById, deleteComment } = useContext(CommentContext)
+    const { user, checkIfStaff } = useContext(NavBarContext)
     const { getPosts } = useContext(PostContext)
     const currentUser = localStorage.getItem("stressLess_user_id")
     const postId = post
+
+    useEffect(() => {
+        checkIfStaff()
+    }, [])
 
     // making date readable to humans
     // const monthDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' }
@@ -99,12 +104,21 @@ export const Comment = ({ commentObj, post }) => {
         <>
             {
                 (commentObj.post_id === post)
-                ? <Card>
+                ? <Card md={4}>
                     <Card.Body>
+                        {/* Admin remove button for app user posts */}
+                        {
+                            (user.is_staff && ! commentObj.owner)
+                            ? <div className="admin-button"><Button variant="danger" onClick={() => {
+                                handleDeleteComment(commentObj.id)
+                                }}>Remove</Button></div>
+                            : null
+                        }
                         <Card.Subtitle>{commentObj.app_user?.full_name}</Card.Subtitle>
                         <Card.Subtitle className="text-muted card-sub">{humanMonthDate} at {humanTime}</Card.Subtitle>
                         {/* ternary to show comment OR if EDIT is TRUE, show comment input form to edit comment */}
                         {
+                            // if edit is true then render comment input form and state
                             (edit)
                             ? <>
                                 <Container>

--- a/src/components/posts/Post.css
+++ b/src/components/posts/Post.css
@@ -27,3 +27,8 @@ a {
 .comment-count:hover {
     cursor: pointer;
 }
+
+.admin-button {
+    display: flex;
+    justify-content: end;
+}

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -2,9 +2,9 @@ import React, { useEffect, useContext, useState } from "react"
 import { PostContext } from "./PostProvider"
 import { CommentList } from "../comments/CommentList"
 import { CommentForm } from "../comments/CommentForm"
+import { NavBarContext } from "../nav/NavBarProvider"
 import { useHistory } from 'react-router'
 import { Container, Row, Col, Button, Card } from "react-bootstrap"
-import { DateTime } from "luxon"
 import * as BsIcons from "react-icons/bs"
 import * as AiIcons from "react-icons/ai"
 import Swal from "sweetalert2"
@@ -14,11 +14,16 @@ import "./Post.css"
 export const Post = ({ postObject }) => {
     // returns individual posts to post list
     const { deletePost, getPosts } = useContext(PostContext)
+    const { user, checkIfStaff } = useContext(NavBarContext)
     const history = useHistory()
 
     const [ showComments, setShowComments ] = useState(false)
     const [ showCommentInput, setShowCommentInput ] = useState(false)
     const [ showButton, setShowButton ] = useState(true)
+
+    useEffect(() => {
+        checkIfStaff()
+    }, [])
 
     // making date readable to humans
     // const monthDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' }
@@ -57,11 +62,25 @@ export const Post = ({ postObject }) => {
         <>
             <Card>
                 <Card.Body>
+                    {/* Admin remove button for app user posts */}
+                    {
+                        (user.is_staff && !postObject.owner)
+                        ? <div className="admin-button"><Button variant="danger" onClick={() => {
+                            handleDeletePost(postObject.id)
+                            }}>Remove</Button></div>
+                        : null
+                    }
                     <Card.Subtitle>{postObject.app_user?.full_name}</Card.Subtitle>
                     <Card.Subtitle className="text-muted"><div>{humanMonthDate} at {humanTime}</div></Card.Subtitle>
                     <Card.Title className="card-title">{postObject.title}</Card.Title>
                     <Card.Text><div>{postObject.content}</div></Card.Text>
-                    <Card.Img src={postObject.image_url} />
+                    {/* Is there an image attached to the post? */}
+                    {
+                        (postObject.image_url !== "")
+                        ? <Card.Img src={postObject.image_url} />
+                        : null
+                    }
+                    {/* Check if user is owner of post to view edit/delete */}
                     {
                         (postObject.owner)
                         // if owner of post show edit and delete buttons
@@ -76,6 +95,7 @@ export const Post = ({ postObject }) => {
                           </>
                         : null
                     }
+                    {/* Show comments is false at page load, if comment count make clickable to show comments */}
                     <Card.Link onClick={() => setShowComments(!showComments)}>
                         {
                             (postObject.comment_count > 0)
@@ -87,21 +107,25 @@ export const Post = ({ postObject }) => {
                     </Card.Link>
                     {
                         (showComments)
-                        // if user clicks above comment count link, showComment state becomes TRUE
+                        // if user clicks above comment count link, showComments state becomes TRUE
+                        // Show list of comments
                         ? <><CommentList postId={postObject.id}/></>
                         : null
                     }
                 </Card.Body>
+                {/* Comment button hide/show and comment input hide/show */}
                 <Card.Body>
                     {
+                        // Showbutton (comment button) is true at page load, onclick set it to false
                         (showButton)
                         ? <Button onClick={() => {
                             setShowButton(!showButton)
+                            // show comment input is false at page load, set it to true
                             setShowCommentInput(!showCommentInput)
                           }}>Comment</Button>
                         : null
                     }
-
+                    {/* Show comment form is true, so pass props to comment form component */}
                     {
                         (showCommentInput)
                         ? <>
@@ -111,7 +135,6 @@ export const Post = ({ postObject }) => {
                           </>
                         : null
                     }
-                    
                 </Card.Body>
             </Card> 
         </>


### PR DESCRIPTION
## Changes

- added ability for admin to remove any and all posts or comments they see fit

## Testing

- [ ] git fetch --all and checkout to branch `client-admin-posts`
- [ ] run server from `stressLess-server`
- [ ] login as admin and navigate to social feed
- [ ] remove a comment or post made by an app user
- [ ] verify modal pops up and comment/post is deleted


## Related Issues

- Stretch Goal - admin has ability to monitor social feed and remove any post or comment they want