### PR TITLE
Admin motivation crud functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12569,6 +12569,11 @@
         "warning": "^4.0.3"
       }
     },
+    "react-card-flip": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-card-flip/-/react-card-flip-1.1.3.tgz",
+      "integrity": "sha512-hTytY1vuoTHFeYJTGuxk8YPjjxJDAGRC9ec5dPgWL71p+pQUYDuPtdzHTnBszp2XRy4w+HSdIoYYqXLIPnkCEA=="
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "luxon": "^2.0.2",
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.0-beta.6",
+    "react-card-flip": "^1.1.3",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
     "react-router-dom": "^5.3.0",

--- a/src/components/AdminApplicationViews.js
+++ b/src/components/AdminApplicationViews.js
@@ -1,25 +1,25 @@
 import React from "react"
 import { Route } from "react-router-dom"
-import { Dashboard } from "./dashboard/Dashboard"
 import { DashboardProvider } from "./dashboard/DashboardProvider"
 import { AdminDashboard } from "./admin/AdminDashboard"
 import { AppUserProvider } from "./users/AppUserProvider"
 import { AppUserList } from "./users/AppUserList"
-import { PriorityForm } from "./priorities/PriorityForm"
-import { AchievementList } from "./achievements/AchievementList"
 import { CommunityFeed } from "./community/CommunityFeed"
 import { PostProvider } from "./posts/PostProvider"
 import { PostForm } from "./posts/PostForm"
 import { CommentProvider } from "./comments/CommentProvider"
+import { MotivationProvider } from "./motivation/MotivationProvider"
 
 
 export const ApplicationViewsTwo = () => {
     return <>
         {/* Render user dashboard upon login */}
         <DashboardProvider>
-                    <Route exact path="/admin/dashboard">
-                        <AdminDashboard />
-                    </Route>
+            <MotivationProvider>
+                <Route exact path="/admin/dashboard">
+                    <AdminDashboard />
+                </Route>
+            </MotivationProvider>
         </DashboardProvider>
 
         {/* Render complete list of current application users */}

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext, useState } from "react"
 import { DashboardContext } from "../dashboard/DashboardProvider"
 import { MotivationList } from "../motivation/MotivationList"
+import { MotivationForm } from "../motivation/MotivationForm"
 import { Container, Row, Col } from "react-bootstrap"
 import "../dashboard/Dashboard.css"
 
@@ -25,7 +26,7 @@ export const AdminDashboard = () => {
                 <Row>
                     <Col>
                         <h3>Create a New Motivation</h3>
-                        <div>Motivation Input Here</div>
+                        <MotivationForm/>
                     </Col>
                 </Row>
                 <Row>

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useContext, useState } from "react"
 import { DashboardContext } from "../dashboard/DashboardProvider"
+import { MotivationList } from "../motivation/MotivationList"
 import { Container, Row, Col } from "react-bootstrap"
 import "../dashboard/Dashboard.css"
 
@@ -19,6 +20,18 @@ export const AdminDashboard = () => {
                     <Col xs={10} md={8}
                     className="dashboard-welcome">
                         <h2>Welcome to StressLess, {dashboard.app_user?.full_name}</h2>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        <h3>Create a New Motivation</h3>
+                        <div>Motivation Input Here</div>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        <h3>Motivation History</h3>
+                        <MotivationList/>
                     </Col>
                 </Row>
             </Container>

--- a/src/components/motivation/Motivation.js
+++ b/src/components/motivation/Motivation.js
@@ -8,11 +8,11 @@ import * as AiIcons from "react-icons/ai"
 
 export const Motivation = () => {
     // returns indivdual achievements to achievement list
-    const { motivation, getMotivation } = useContext(MotivationContext)
+    const { motivation, getNewestMotivation } = useContext(MotivationContext)
     const history = useHistory()
 
     useEffect(() => {
-        getMotivation()
+        getNewestMotivation()
     }, [])
     
     

--- a/src/components/motivation/MotivationCard.js
+++ b/src/components/motivation/MotivationCard.js
@@ -8,6 +8,7 @@ import * as BsIcons from "react-icons/bs"
 
 export const MotivationCard = ({ motivationObj }) => {
     // returns individual reflections to reflection list
+    const { deleteMotivation, editMotivation } = useContext(MotivationContext)
     
 
     // making date readable to humans
@@ -28,6 +29,11 @@ export const MotivationCard = ({ motivationObj }) => {
                 </Card.Subtitle>
                 <Card.Text><div>{motivationObj.title}</div></Card.Text>
                 <Card.Text><div>{motivationObj.content}</div></Card.Text>
+                <Card.Body className="post-btn-group">
+                    <Card.Link className="edit-icon" onClick={() => {
+                        deleteMotivation(motivationObj.id)
+                    }}><BsIcons.BsTrashFill/></Card.Link>
+                </Card.Body>
             </Card.Body>
         </Card>
         </>

--- a/src/components/motivation/MotivationCard.js
+++ b/src/components/motivation/MotivationCard.js
@@ -23,7 +23,9 @@ export const MotivationCard = ({ motivationObj }) => {
         <>
         <Card>
             <Card.Body>
-                <Card.Subtitle className="text-muted card-sub"><div>{humanMonthDate} at {humanTime}</div></Card.Subtitle>
+                <Card.Subtitle className="text-muted card-sub">
+                    <div>Created {humanMonthDate} at {humanTime}</div>
+                </Card.Subtitle>
                 <Card.Text><div>{motivationObj.title}</div></Card.Text>
                 <Card.Text><div>{motivationObj.content}</div></Card.Text>
             </Card.Body>

--- a/src/components/motivation/MotivationCard.js
+++ b/src/components/motivation/MotivationCard.js
@@ -1,41 +1,122 @@
 import React, { useEffect, useContext, useState } from "react"
 import { MotivationContext } from "./MotivationProvider"
 import { useHistory } from 'react-router'
-import { Container, Row, Col, Button, Card } from "react-bootstrap"
+import { Container, Row, Col, Button, Card, Form } from "react-bootstrap"
+import ReactCardFlip from 'react-card-flip'
 import { DateTime } from "luxon"
 import * as BsIcons from "react-icons/bs"
 
 
 export const MotivationCard = ({ motivationObj }) => {
     // returns individual reflections to reflection list
-    const { deleteMotivation, editMotivation } = useContext(MotivationContext)
-    
+    const { deleteMotivation, editMotivation, getMotivationById } = useContext(MotivationContext)
+    const currentUser = localStorage.getItem("stressLess_user_id")
+    const now = DateTime.now()
+    const [isFlipped, setIsFlipped] = useState(false)
+    const [editMode, setEditMode] = useState(false)
+    const [ currentMotivation, setCurrentMotivation ] = useState({
+        appUser: currentUser,
+        title: "",
+        content: "",
+        createdOn: ""
+    })
+
+
+    useEffect(() => {
+        if (editMode === true) {
+            getMotivationById(motivationObj.id).then(m => {
+                setCurrentMotivation({
+                    appUser: currentUser,
+                    title: m.title,
+                    content: m.content,
+                    createdOn: m.created_on
+                })
+            })
+        }
+    }, [editMode])
 
     // making date readable to humans
     // const monthDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' }
     const date = new Date(motivationObj.created_on)
-    const monthDate = { weekday: 'long' }
+    const monthDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
     const time = { hour: 'numeric', minute: 'numeric' }
     const humanMonthDate = date.toLocaleDateString('en-US', monthDate)
     const humanTime = date.toLocaleString('en-US', time)
     
+    // function to handle flipping card
+    const handleFlip = () => {
+        setIsFlipped(!isFlipped)
+    }
+
+    const handleUserInput = (event) => {
+        const newMotivationState = {...currentMotivation}
+        newMotivationState[event.target.name] = event.target.value
+        setCurrentMotivation(newMotivationState)
+    }
+
+    const handleEditMotivation = (event) => {
+        event.preventDefault()
+        
+        const motivation = {
+            id: motivationObj.id,
+            appUser: currentUser,
+            title: currentMotivation.title,
+            content: currentMotivation.content,
+            createdOn: now.toISODate()
+        }
+        // send PUT request to API
+        editMotivation(motivation)
+            .then((event) => {
+                setEditMode(false)
+                handleFlip(event)
+            })
+    }
     
     return (
         <>
-        <Card>
-            <Card.Body>
-                <Card.Subtitle className="text-muted card-sub">
-                    <div>Created {humanMonthDate} at {humanTime}</div>
-                </Card.Subtitle>
-                <Card.Text><div>{motivationObj.title}</div></Card.Text>
-                <Card.Text><div>{motivationObj.content}</div></Card.Text>
-                <Card.Body className="post-btn-group">
-                    <Card.Link className="edit-icon" onClick={() => {
-                        deleteMotivation(motivationObj.id)
-                    }}><BsIcons.BsTrashFill/></Card.Link>
+        <ReactCardFlip isFlipped={isFlipped} flipDirection="vertical">
+            <Card>
+                <Card.Body>
+                    <Card.Subtitle className="text-muted card-sub">
+                        <div>Created {humanMonthDate}</div>
+                    </Card.Subtitle>
+                    <Card.Text><div>Question: {motivationObj.title}</div></Card.Text>
+                    <Card.Text><div>Notes: {motivationObj.content}</div></Card.Text>
+                    <Card.Body className="post-btn-group">
+                        <Card.Link className="edit-icon" onClick={() => {
+                            deleteMotivation(motivationObj.id)
+                        }}><BsIcons.BsTrashFill/></Card.Link>
+                        <Button className="button" onClick={() => {
+                            setEditMode(true)
+                            handleFlip()
+                        }}>Edit</Button>
+                    </Card.Body>
                 </Card.Body>
-            </Card.Body>
-        </Card>
+            </Card>
+            <Card>
+                <Card.Body>
+                    <Form>
+                        <Form.Group>
+                            <Form.Control as="input"
+                            name="title" value={currentMotivation.title}
+                            onChange={handleUserInput} placeholder="Enter question or motivation" required/>
+                            <Form.Control as="textarea" row={3}
+                            name="content" value={currentMotivation.content}
+                            onChange={handleUserInput} placeholder="Any additional notes?" required/>
+                            <Form.Group className="post-form-btn-group">
+                                <Button type="submit" className="post-form-btn button"
+                                onClick={handleEditMotivation}>Submit</Button>
+                                <Button type="button" className="post-form-btn button"
+                                onClick={() => {
+                                    setEditMode(false)
+                                    handleFlip()
+                                }}>Cancel</Button>
+                            </Form.Group>
+                        </Form.Group>
+                    </Form>
+                </Card.Body>
+            </Card>
+        </ReactCardFlip>
         </>
     )
 }

--- a/src/components/motivation/MotivationCard.js
+++ b/src/components/motivation/MotivationCard.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useContext, useState } from "react"
+import { MotivationContext } from "./MotivationProvider"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button, Card } from "react-bootstrap"
+import { DateTime } from "luxon"
+import * as BsIcons from "react-icons/bs"
+
+
+export const MotivationCard = ({ motivationObj }) => {
+    // returns individual reflections to reflection list
+    
+
+    // making date readable to humans
+    // const monthDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' }
+    const date = new Date(motivationObj.created_on)
+    const monthDate = { weekday: 'long' }
+    const time = { hour: 'numeric', minute: 'numeric' }
+    const humanMonthDate = date.toLocaleDateString('en-US', monthDate)
+    const humanTime = date.toLocaleString('en-US', time)
+    
+    
+    return (
+        <>
+        <Card>
+            <Card.Body>
+                <Card.Subtitle className="text-muted card-sub"><div>{humanMonthDate} at {humanTime}</div></Card.Subtitle>
+                <Card.Text><div>{motivationObj.title}</div></Card.Text>
+                <Card.Text><div>{motivationObj.content}</div></Card.Text>
+            </Card.Body>
+        </Card>
+        </>
+    )
+}
+

--- a/src/components/motivation/MotivationForm.js
+++ b/src/components/motivation/MotivationForm.js
@@ -31,7 +31,7 @@ export const MotivationForm = () => {
             appUser: currentUser,
             title: currentMotivation.title,
             content: currentMotivation.content,
-            createdOn: now.toISO()
+            createdOn: now.toISODate()
         }
 
         if (currentMotivation.content === "" || currentMotivation.title === "") {
@@ -64,7 +64,8 @@ export const MotivationForm = () => {
                                 name="content" value={currentMotivation.content}
                                 onChange={handleUserInput} placeholder="Your wise words here" required/>
                                 <Form.Group className="post-form-btn-group">
-                                    <Button type="submit" className="post-form-btn button" onClick={handleSaveMotivation}>Submit</Button>
+                                    <Button type="submit" className="post-form-btn button"
+                                    onClick={handleSaveMotivation}>Submit</Button>
                                 </Form.Group>
                             </Form.Group>
                         </Form>

--- a/src/components/motivation/MotivationForm.js
+++ b/src/components/motivation/MotivationForm.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useContext, useState } from "react"
+import { MotivationContext } from "./MotivationProvider"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button, Form } from "react-bootstrap"
+import { DateTime } from "luxon"
+
+
+
+export const MotivationForm = () => {
+    const {createMotivation} = useContext(MotivationContext)
+    const currentUser = localStorage.getItem("stressLess_user_id")
+    const now = DateTime.now()
+
+    const [ currentMotivation, setCurrentMotivation ] = useState({
+        appUser: currentUser,
+        title: "",
+        content: "",
+        createdOn: ""
+    })
+
+    const handleUserInput = (event) => {
+        const newMotivationState = {...currentMotivation}
+        newMotivationState[event.target.name] = event.target.value
+        setCurrentMotivation(newMotivationState)
+    }
+
+    const handleSaveMotivation = (event) => {
+        event.preventDefault()
+
+        const newMotivation = {
+            appUser: currentUser,
+            title: currentMotivation.title,
+            content: currentMotivation.content,
+            createdOn: now.toISO()
+        }
+
+        if (currentMotivation.content === "" || currentMotivation.title === "") {
+            return
+        } else {
+            // send POST request to API
+            createMotivation(newMotivation)
+                .then(() => {
+                    setCurrentMotivation({
+                        appUser: currentUser,
+                        title: "",
+                        content: "",
+                        createdOn: ""
+                    })
+                })
+        }
+    }
+
+    return (
+        <>
+            <Container>
+                <Row>
+                    <Col className="form-input" md={6}>
+                        <Form>
+                            <Form.Group>
+                                <Form.Control as="input"
+                                name="title" value={currentMotivation.title}
+                                onChange={handleUserInput} placeholder="Title" required/>
+                                <Form.Control as="textarea" row={3}
+                                name="content" value={currentMotivation.content}
+                                onChange={handleUserInput} placeholder="Your wise words here" required/>
+                                <Form.Group className="post-form-btn-group">
+                                    <Button type="submit" className="post-form-btn button" onClick={handleSaveMotivation}>Submit</Button>
+                                </Form.Group>
+                            </Form.Group>
+                        </Form>
+                    </Col>
+                </Row>
+            </Container>
+        </>
+    )
+}

--- a/src/components/motivation/MotivationForm.js
+++ b/src/components/motivation/MotivationForm.js
@@ -34,7 +34,7 @@ export const MotivationForm = () => {
             createdOn: now.toISODate()
         }
 
-        if (currentMotivation.content === "" || currentMotivation.title === "") {
+        if (currentMotivation.title === "") {
             return
         } else {
             // send POST request to API
@@ -59,10 +59,10 @@ export const MotivationForm = () => {
                             <Form.Group>
                                 <Form.Control as="input"
                                 name="title" value={currentMotivation.title}
-                                onChange={handleUserInput} placeholder="Title" required/>
+                                onChange={handleUserInput} placeholder="Enter question or motivation" required/>
                                 <Form.Control as="textarea" row={3}
                                 name="content" value={currentMotivation.content}
-                                onChange={handleUserInput} placeholder="Your wise words here" required/>
+                                onChange={handleUserInput} placeholder="Any additional notes?" required/>
                                 <Form.Group className="post-form-btn-group">
                                     <Button type="submit" className="post-form-btn button"
                                     onClick={handleSaveMotivation}>Submit</Button>

--- a/src/components/motivation/MotivationList.js
+++ b/src/components/motivation/MotivationList.js
@@ -13,7 +13,7 @@ export const MotivationList = () => {
     }, [])
 
     const sortedMotivations = allMotivations.sort((a, b) => {
-        return b.created_on.localeCompare(a.created_on)
+        return b.id - a.id
     })
 
 

--- a/src/components/motivation/MotivationList.js
+++ b/src/components/motivation/MotivationList.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useContext, useState } from "react"
+import { MotivationContext } from "./MotivationProvider"
+import { MotivationCard } from "./MotivationCard"
+import { useHistory } from 'react-router'
+import { Container, Row, Col, Button } from "react-bootstrap"
+
+export const MotivationList = () => {
+    const { allMotivations, getAllMotivations } = useContext(MotivationContext)
+    const history = useHistory()
+
+    useEffect(() => {
+        getAllMotivations()
+    }, [])
+
+    const sortedMotivations = allMotivations.sort((a, b) => {
+        return b.created_on.localeCompare(a.created_on)
+    })
+
+
+    return (
+        <>
+            <Container className="post-container">
+                <Row>
+                    <Col> 
+                        {
+                            sortedMotivations.map(motivation => {
+                                return <MotivationCard motivationObj={motivation} key={motivation.id} />
+                            })
+                        }
+                    </Col>
+                </Row>
+            </Container>
+        </>
+    )
+}

--- a/src/components/motivation/MotivationProvider.js
+++ b/src/components/motivation/MotivationProvider.js
@@ -30,11 +30,26 @@ export const MotivationProvider = (props) => {
         .then(setAllMotivations)
       }
 
+      const createMotivation = motivationObj => {
+        return fetch("http://localhost:8000/motivations", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            },
+            body: JSON.stringify(motivationObj)
+        })
+        .then(getAllMotivations)
+        .then()
+    }
+      
+
       return (
           <MotivationContext.Provider value={
               {
                   motivation, getNewestMotivation,
-                  allMotivations, getAllMotivations
+                  allMotivations, getAllMotivations,
+                  createMotivation
               }
           }>
               {props.children}

--- a/src/components/motivation/MotivationProvider.js
+++ b/src/components/motivation/MotivationProvider.js
@@ -41,15 +41,40 @@ export const MotivationProvider = (props) => {
         })
         .then(getAllMotivations)
         .then()
-    }
+      }
+
+      const editMotivation = motivation => {
+        return fetch(`http://localhost:8000/motivations/${motivation.id}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            },
+            body: JSON.stringify(motivation)
+        })
+        .then(getAllMotivations)
+        .then()
+      }
+
+      const deleteMotivation = motivationId => {
+        return fetch(`http://localhost:8000/motivations/${motivationId}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(getAllMotivations)
+      }
       
+
 
       return (
           <MotivationContext.Provider value={
               {
                   motivation, getNewestMotivation,
                   allMotivations, getAllMotivations,
-                  createMotivation
+                  createMotivation, deleteMotivation,
+                  editMotivation
               }
           }>
               {props.children}

--- a/src/components/motivation/MotivationProvider.js
+++ b/src/components/motivation/MotivationProvider.js
@@ -4,9 +4,10 @@ export const MotivationContext = createContext()
 
 export const MotivationProvider = (props) => {
     const [motivation, setMotivation] = useState({})
+    const [allMotivations, setAllMotivations] = useState([])
 
-    const getMotivation = () => {
-        return fetch("http://localhost:8000/motivation", { 
+    const getNewestMotivation = () => {
+        return fetch("http://localhost:8000/motivations?sortBy=date", { 
             method: "GET",
             headers: {
               Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
@@ -17,10 +18,23 @@ export const MotivationProvider = (props) => {
         .then(setMotivation)
       }
 
+      const getAllMotivations = () => {
+        return fetch("http://localhost:8000/motivations", { 
+            method: "GET",
+            headers: {
+              Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+          }
+        )
+        .then((res) => res.json())
+        .then(setAllMotivations)
+      }
+
       return (
           <MotivationContext.Provider value={
               {
-                  motivation, getMotivation
+                  motivation, getNewestMotivation,
+                  allMotivations, getAllMotivations
               }
           }>
               {props.children}

--- a/src/components/motivation/MotivationProvider.js
+++ b/src/components/motivation/MotivationProvider.js
@@ -30,6 +30,16 @@ export const MotivationProvider = (props) => {
         .then(setAllMotivations)
       }
 
+      const getMotivationById = motivationId => {
+        return fetch(`http://localhost:8000/motivations/${motivationId}`, {
+            headers: {
+                Authorization: `Token ${localStorage.getItem("stressLess_user_id")}`
+            }
+        })
+        .then(res => res.json())
+      }
+
+
       const createMotivation = motivationObj => {
         return fetch("http://localhost:8000/motivations", {
             method: "POST",
@@ -74,7 +84,7 @@ export const MotivationProvider = (props) => {
                   motivation, getNewestMotivation,
                   allMotivations, getAllMotivations,
                   createMotivation, deleteMotivation,
-                  editMotivation
+                  editMotivation, getMotivationById
               }
           }>
               {props.children}

--- a/src/components/users/AppUser.js
+++ b/src/components/users/AppUser.js
@@ -20,29 +20,55 @@ export const AppUser = ({ userObj }) => {
     
     return (
         <>
-            <Card>
-                <Card.Body>
-                    <Card.Text><div>{userObj.full_name}</div></Card.Text>
-                    <Card.Subtitle className="text-muted card-sub">
-                        <div>Date Joined: {humanMonthDate} at {humanTime}</div>
-                    </Card.Subtitle>
-                    <Card.Text><div>Username: {userObj.user?.username}</div></Card.Text>
-                    <Card.Text>
-                        <div>Is Staff?</div>
+            {
+                (userObj.user?.is_active)
+                ?   <Card>
+                        <Card.Body>
+                            <Card.Text><div>{userObj.full_name}</div></Card.Text>
+                            <Card.Subtitle className="text-muted card-sub">
+                                <div>Date Joined: {humanMonthDate} at {humanTime}</div>
+                            </Card.Subtitle>
+                            <Card.Text><div>Username: {userObj.user?.username}</div></Card.Text>
+                            <Card.Text>
+                                <div>Is Staff?</div>
+                                {
+                                    (userObj.user?.is_staff)
+                                    ? <>True</>
+                                    : <>False</>
+                                }
+                            </Card.Text>
+                            {
+                                (userObj.user?.is_active)
+                                ? <><Button className="button">Active</Button></>
+                                : <><Button variant="secondary">Inactive</Button></>
+                            }
+                            
+                        </Card.Body>
+                    </Card>
+                : <Card bg="light" border="dark">
+                    <Card.Body>
+                        <Card.Text><div>{userObj.full_name}</div></Card.Text>
+                        <Card.Subtitle className="text-muted card-sub">
+                            <div>Date Joined: {humanMonthDate} at {humanTime}</div>
+                        </Card.Subtitle>
+                        <Card.Text><div>Username: {userObj.user?.username}</div></Card.Text>
+                        <Card.Text>
+                            <div>Is Staff?</div>
+                            {
+                                (userObj.user?.is_staff)
+                                ? <>True</>
+                                : <>False</>
+                            }
+                        </Card.Text>
                         {
-                            (userObj.user?.is_staff)
-                            ? <>True</>
-                            : <>False</>
+                            (userObj.user?.is_active)
+                            ? <><Button className="button">Active</Button></>
+                            : <><Button variant="secondary">Inactive</Button></>
                         }
-                    </Card.Text>
-                    {
-                        (userObj.user?.is_active)
-                        ? <><Button className="button">Active</Button></>
-                        : <><Button variant="secondary">Inactive</Button></>
-                    }
-                    
-                </Card.Body>
-            </Card>   
+                        
+                    </Card.Body>
+                </Card>
+            }
         </>
     )
 }


### PR DESCRIPTION
## Changes

- added motivation dir with provider and motivationlist.js and motivationCard.js components
- added npm flipping card effect for admin dash
- admin can create, edit, and delete a motivational piece
- added styling to inactive users in admin account


## Testing

- [ ] git fetch --all and checkout to branch `admin-motivation`
- [ ] run server from `stressLess-server`
- [ ] login as admin and create a new motivation
- [ ] verify new object gets added to list of motivations
- [ ] logout and login back in as user and verify new motivation appears in dash under welcome


## Related Issues

- Stretch Goal - admin can create, edit, delete motivational pieces to be published to user dash's